### PR TITLE
Change catch calculations & descriptions

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -52,6 +52,14 @@ class Search extends Command {
     }
   }
 
+  calculateCatchChance(pokeBall, blob) {
+    const b = pokeBall.potential;
+    const r = blob.rarity_scalar;
+
+    // magic do not touch
+    return Math.max(Math.min((5.8 * 10**-5) * r**2 + (-0.01) * r + (4.8 * 10**-5) * b**2 + (0.004) * b + (0.5), 1), 0);
+  }
+
   async run(message, args, level) { // eslint-disable-line no-unused-vars
     const settings = message.settings;
     const connection = await this.client.db.acquire();
@@ -105,7 +113,7 @@ class Search extends Command {
           return message.channel.send(`You try to use your ${usedBall.name}, but for some reason it's disappeared from you. Did you use it elsewhere?`);
         }
 
-        let successChance = usedBall.potential / 100;
+        let successChance = this.calculateCatchChance(usedBall, blob);
         let catchRoll = Math.random();
 
         if (catchRoll < successChance) {
@@ -146,7 +154,7 @@ class Search extends Command {
             return message.channel.send(`You try to use your ${usedBall.name}, but for some reason it's disappeared from you. Did you use it elsewhere?`);
           }
 
-          successChance = usedBall.potential / 100;
+          successChance = this.calculateCatchChance(usedBall, blob);
           catchRoll = Math.random();
 
           if (catchRoll < successChance) {

--- a/setup.sql
+++ b/setup.sql
@@ -195,10 +195,10 @@ COPY itemmodes (id) FROM stdin;
 \.
 
 COPY itemdefs (id, name, value, potential, mode, description, confirm_use_message) FROM stdin;
-1	Basic Ball	5	30	1	A device to catch blobs with 30% chance of success	30% catch rate!
-2	Great Ball	25	50	1	A device to catch blobs with 50% chance of success	50% catch rate!
-3	Ultra Ball	50	75	1	A device to catch blobs with 75% chance of success	75% catch rate!
-4	Master Ball	80	95	1	A device to catch blobs with 95% chance of success	95% catch rate!
+1	Basic Ball	5	30	1	Basic blob capture device. Good for common blobs, struggles on rarer types.	.
+2	Great Ball	25	50	1	A step up from the Basic Ball, great on common blobs and decent on rare blobs.	.
+3	Ultra Ball	50	75	1	A more powerful Ball that offers a great chance for all blobs.	.
+4	Master Ball	80	95	1	The gold standard, catches blobs almost every time.	.
 5	Spikey Fruit	15	5	2	Regenerates 5 energy	regenerating 5 energy.
 6	Pudding	40	15	2	Regenerates 15 energy	regenerating 15 energy.
 7	Sugar Cube	70	30	2	Regenerates 30 energy	regenerating 15 energy.


### PR DESCRIPTION
A little magic-number-y but the numbers fit closer to an ideal model:
![image](https://user-images.githubusercontent.com/8049998/35129143-7d13c91c-fcfd-11e7-9112-381ac5fa5079.png)
This also generalizes the item descriptions so that they no longer use exact number quotes.