### PR TITLE
Change the way blobs are ordered in DB requests.

### DIFF
--- a/util/db.js
+++ b/util/db.js
@@ -208,11 +208,16 @@ class DatabaseBackend {
     const member = await this.ensureMember(client, guildID, memberID);
     const res = await client.query(`
       SELECT blobs.unique_id, blobs.blob_id, blobs.caught, blobs.amount,
-      blobdefs.emoji_id, blobdefs.emoji_name
+      blobdefs.emoji_id, blobdefs.emoji_name,
+      blobrarity.rarity_scalar
       FROM blobs
       INNER JOIN blobdefs ON blobs.blob_id = blobdefs.unique_id
+      INNER JOIN blobrarity ON blobdefs.rarity = blobrarity.id
       WHERE user_id = $1::BIGINT
-      ORDER BY blobdefs.rarity DESC
+      ORDER BY
+      blobrarity.rarity_scalar DESC,
+      blobs.amount DESC,
+      blobdefs.emoji_name ASC
     `, [member.unique_id]);
     return res.rows;
   }


### PR DESCRIPTION
This changes the request for a user's blobs like so:
* The rarity scalar is now included in blob information, in case we ever need it for something
* The order in which the records are returned is changed to this ordering:
  - Highest rarity scalar first
  - Most owned first
  - Alphabetical order of emoji name

Pretty simple change, but previously we were ordering by most common first, which isn't super helpful.