### PR TITLE
Allow user IDs for the -user command

### DIFF
--- a/commands/user.js
+++ b/commands/user.js
@@ -14,11 +14,12 @@ class User extends Command {
   }
 
   async run(message, args, level) { // eslint-disable-line no-unused-vars
-    const allArgs = args.join(' ');
+    const allArgs = args.join(' ').trim();
     const firstMention = message.mentions.users.first();
     let parseID;
     if (!isNaN(allArgs)) parseID = message.guild.member(allArgs);
     const target = (firstMention) ? firstMention : (parseID) ? parseID.user : message.author;
+
     const connection = await this.client.db.acquire();
     let userData, inventory, blobData, effectData;
     try {

--- a/commands/user.js
+++ b/commands/user.js
@@ -14,8 +14,11 @@ class User extends Command {
   }
 
   async run(message, args, level) { // eslint-disable-line no-unused-vars
+    const allArgs = args.join(' ');
     const firstMention = message.mentions.users.first();
-    const target = (firstMention) ? firstMention : message.author;
+    let parseID;
+    if (!isNaN(allArgs)) parseID = message.guild.member(allArgs);
+    const target = (firstMention) ? firstMention : (parseID) ? parseID.user : message.author;
     const connection = await this.client.db.acquire();
     let userData, inventory, blobData, effectData;
     try {


### PR DESCRIPTION
Same code as in the `-blobs` command, allows an ID to be used instead of a mention.