### PR TITLE
Interactive trade implementation

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -1,85 +1,326 @@
 const Command = require('../base/Command.js');
+const { MessageEmbed } = require('discord.js');
 
 class Trade extends Command {
   constructor(client) {
     super(client, {
       name: 'trade',
-      description: 'Trade blobs with a user.',
+      description: 'Starts interactive trade with a user.',
       category: 'Pokéblob',
-      usage: 'trade <your blob> <users blob>',
+      usage: 'trade <user>',
       guildOnly: true,
       extended: 'Trade one of your blobs for one of another users blobs. This requires the other user to accept the trade.',
       botPerms: ['SEND_MESSAGES'],
       permLevel: 'User'
     });
+    this.activeTrades = new Map();
   }
 
-  async run(message, [mention, yourBlob, usersBlob], level) { // eslint-disable-line no-unused-vars
-    const settings = message.settings;
-    const correspondent = message.mentions.users.first();
+  async run(message, args, level) { // eslint-disable-line no-unused-vars
+    if (this.activeTrades.has(message.author.id))
+      return message.channel.send('Finish your active trade first, then we can talk.');
+
+    const allArgs = args.join(' ').trim();
+    const firstMention = message.mentions.members.first();
+    let parseID;
+    if (!isNaN(allArgs)) parseID = message.guild.member(allArgs);
+    const correspondent = (firstMention) ? firstMention : parseID;
+
     if (!correspondent)
-      return message.channel.send('You must choose someone to trade with!');
+      return message.channel.send('I don\'t understand who you\'re trying to trade with. Try using their mention.');
+
+    if ((new Date() - message.member.joinedAt) < 604800000)
+      return message.channel.send('You haven\'t been in the server long enough to initiate trades yet.');
+
+    if ((new Date() - correspondent.joinedAt) < 604800000)
+      return message.channel.send('That person hasn\'t been in the server long enough to engage in trades yet.');
+    
+    const settings = message.settings;
     const connection = await this.client.db.acquire();
+
+    this.activeTrades.set(message.author.id);
+
     try {
-      const yourBlobData = await this.client.db.getBlobByName(connection, yourBlob);
-      const usersBlobData = await this.client.db.getBlobByName(connection, usersBlob);
-      if (!yourBlobData) {
-        return message.channel.send('I can\'t work out what blob you\'re trying to trade away (use its full name!).');
-      } else if (!usersBlobData) {
-        return message.channel.send('I can\'t work out what blob you\'re trying to trade for (use its full name!).');
+      const initiaterBlobs = await this.client.db.getUserBlobs(connection, message.guild.id, message.author.id);
+      const correspondentBlobs = await this.client.db.getUserBlobs(connection, message.guild.id, correspondent.user.id);
+
+      if (initiaterBlobs.filter(x => x.caught).length < 5)
+        return message.channel.send('You don\'t have enough blob-catching experience to engage in trades yet.');
+
+      if (correspondentBlobs.filter(x => x.caught).length < 5)
+        return message.channel.send('That person hasn\'t had enough blob-catching experience to trade with you yet.');
+
+      const state = {
+        offerItems: new Map(),
+        offerBlobs: new Map(),
+        offerCoins: 0,
+        requestItems: new Map(),
+        requestBlobs: new Map(),
+        requestCoins: 0,
+        finished: false,
+        continue: false,
+        timeout: false
+      };
+      
+      let tradeMsg = null;
+
+      const mainDesc = `\`${settings.prefix}<offer|request>blob [blob]\` to offer/request a blob.\n\`${settings.prefix}<offer|request>item [item]\` to offer/request an item.\n\`${settings.prefix}<offer|request>coins [amount]\` to offer/request coins.\n\n\`${settings.prefix}confirm\` if you're ready to trade.\n\`${settings.prefix}cancel\` to cancel this offer.`;
+
+      while (!state.finished) {
+        if (tradeMsg)
+          tradeMsg.delete();
+        
+        const tradeEmbed = this.makeTradeEmbed(message, state).setDescription(`Setting up trade with ${correspondent.user} (${correspondent.user.tag})..\n\n${mainDesc}`);
+        tradeMsg = await message.channel.send({ embed: tradeEmbed });
+
+        await this.processInteractive(connection, message, state);
       }
 
-      const conformers = await this.client.db.checkHasBlobs(connection, message.guild.id, message.author.id, yourBlobData.unique_id, correspondent.id, usersBlobData.unique_id);
-      if (conformers.length !== 2) {
-        if (conformers.includes(message.author.id)) {
-          return message.channel.send('Not engaging a trade because the other user doesn\'t have the blob you want.');
-        } else {
-          return message.channel.send('Not engaging a trade because you don\'t have the blob you\'re trying to trade away.');
-        }
-      }
+      if (tradeMsg)
+        tradeMsg.delete();
 
-      message.channel.send(`Trading your <:${yourBlobData.emoji_name}:${yourBlobData.emoji_id}> for ${correspondent.tag}'s <:${usersBlobData.emoji_name}:${usersBlobData.emoji_id}>.\nType\`-confirm\` to send a trade request\nType \`-cancel\` to cancel trade.`);
-      const filter = m => (m.author.id === message.author.id && [`${settings.prefix}confirm`, `${settings.prefix}cancel`].includes(m.content));
-      let response;
+      if (!state.continue)
+        if (state.timeout)
+          return message.channel.send(`${message.author} Your pending trade timed out.`);
+        else
+          return message.channel.send('Trade cancelled.');
+      
+      if (Math.max.apply(null, [state.offerItems.size, state.offerBlobs.size, state.offerCoins, state.requestItems.size, state.requestBlobs.size, state.requestCoins]) === 0)
+        return message.channel.send('Trade completed. It actually didn\'t, but nothing would have happened if it had anyway.');
+
+      await message.channel.send(`${correspondent.user}, ${message.author} wants to trade with you.\n\`${settings.prefix}accept\` to accept, \n\`${settings.prefix}decline\` to decline.`, { embed: this.makeTradeEmbed(message, state).setDescription(`Wants to trade with ${correspondent.user} (${correspondent.user.tag})`) });
+
+      const responseFilter = m => (m.author.id === correspondent.user.id && [`${settings.prefix}accept`, `${settings.prefix}decline`].includes(m.content));
+
+      let responseMessage;
       try {
-        response = (await message.channel.awaitMessages(filter, { max: 1, time: 60000, errors: ['time'] })).first().content;
+        responseMessage = (await message.channel.awaitMessages(responseFilter, { max: 1, time: 60000, errors: ['time'] })).first().content;
       } catch (e) {
-        return;
+        return message.channel.send(`${message.author} Your trade didn't complete because your partner took too long.`);
       }
-      if (response === `${settings.prefix}confirm`) {
-        message.channel.send(`${correspondent} Please confirm trade with ${message.author.tag}. Trading your <:${usersBlobData.emoji_name}:${usersBlobData.emoji_id}> for ${message.author.tag}'s <:${yourBlobData.emoji_name}:${yourBlobData.emoji_id}>`);
-        const filter = m => (m.author.id === correspondent.id && [`${settings.prefix}confirm`, `${settings.prefix}cancel`].includes(m.content));
-        let response;
-        try {
-          response = (await message.channel.awaitMessages(filter, { max: 1, time: 60000, errors: ['time'] })).first().content;
-        } catch (e) {
-          return;
-        }
-        if (response === `${settings.prefix}confirm`) {
-          await connection.query('BEGIN');
 
-          const takeFromProvider = await this.client.db.takeUserBlob(connection, message.guild.id, message.author.id, yourBlobData.unique_id, 1);
-          const takeFromCorrespondent = await this.client.db.takeUserBlob(connection, message.guild.id, correspondent.id, usersBlobData.unique_id, 1);
-          await this.client.db.giveUserBlob(connection, message.guild.id, message.author.id, usersBlobData.unique_id, 1);
-          await this.client.db.giveUserBlob(connection, message.guild.id, correspondent.id, yourBlobData.unique_id, 1);
-
-          if (!takeFromProvider) {
-            await connection.query('ROLLBACK');
-            return message.channel.send(`Couldn't trade, ${message.author.tag} doesn't have a <:${yourBlobData.emoji_name}:${yourBlobData.emoji_id}>!`);
-          } else if (!takeFromCorrespondent) {
-            await connection.query('ROLLBACK');
-            return message.channel.send(`Couldn't trade, ${correspondent.tag} doesn't have a <:${usersBlobData.emoji_name}:${usersBlobData.emoji_id}>!`);
-          } else {
-            await connection.query('COMMIT');
-            this.client.log('Log', `A trade has been performed swapping ${message.author.id}'s ${yourBlobData.emoji_name} (${yourBlobData.unique_id}) for ${correspondent.id}'s ${usersBlobData.emoji_name} (${usersBlobData.unique_id}).`, 'Trade');
-            return message.channel.send(`Trade between ${message.author.tag} and ${correspondent.tag} confirmed.`);
-          }
-        } else if (response === `${settings.prefix}cancel`) {
-          message.channel.send(`Trade between ${message.author.tag} and ${correspondent.tag} cancelled.`);
-        }
+      if (responseMessage === `${settings.prefix}accept`) {
+        const complaint = await this.attemptPerformTrade(connection, message, state, correspondent);
+        if (complaint)
+          return message.channel.send(`The trade couldn't be completed: ${complaint}`);
+        else
+          return message.channel.send(`${message.author} Your trade with ${correspondent.user} completed successfully.`);
+      } else {
+        return message.channel.send(`${message.author} Your trade was declined.`);
       }
     } finally {
       connection.release();
+      this.activeTrades.delete(message.author.id);
+    }
+  }
+
+  makeTradeEmbed(message, state) {
+    var embed = new MessageEmbed()
+      .setAuthor(message.author.username, message.author.displayAvatarURL())
+      .setTimestamp()
+      .setFooter('PokéBlobs');
+
+    let offersList = [];
+    let requestsList = [];
+
+    if (state.offerCoins !== 0)
+      offersList.push(`**${state.offerCoins}** <:blobcoin:398579309276823562>`);
+    if (state.requestCoins !== 0)
+      requestsList.push(`**${state.requestCoins}** <:blobcoin:398579309276823562>`);
+
+    offersList = offersList.concat(Array.from(state.offerBlobs.values()).filter(x => x.amount > 0).map(x => `${x.amount}x <:${x.definition.emoji_name}:${x.definition.emoji_id}>`));
+    requestsList = requestsList.concat(Array.from(state.requestBlobs.values()).filter(x => x.amount > 0).map(x => `${x.amount}x <:${x.definition.emoji_name}:${x.definition.emoji_id}>`));
+
+    offersList = offersList.concat(Array.from(state.offerItems.values()).filter(x => x.amount > 0).map(x => `${x.amount}x ${x.definition.name}`));
+    requestsList = requestsList.concat(Array.from(state.requestItems.values()).filter(x => x.amount > 0).map(x => `${x.amount}x ${x.definition.name}`));
+
+    const offerFormatting = (offersList.length > 0) ? offersList.join(', ') : 'Nothing';
+    const requestFormatting = (requestsList.length > 0) ? requestsList.join(', ') : 'Nothing';
+
+    if (offersList.length === 0 && requestsList.length > 0)
+      // potentially dodgy trade?
+      embed = embed.setColor([255, 0, 0]);
+
+    embed = embed.addField('Offering', offerFormatting).addField('Requesting', requestFormatting);
+
+    return embed;
+  }
+
+  async processInteractive(connection, message, state) {
+    const escapedPrefix = message.settings.prefix.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    const interactivityRegex = new RegExp(`^${escapedPrefix}(confirm|cancel|(offer|request)(item|blob|coin)s?)(.*)$`);
+
+    const filter = m => (m.author.id === message.author.id && interactivityRegex.test(m.content));
+
+    let response;
+    try {
+      response = interactivityRegex.exec((await message.channel.awaitMessages(filter, { max: 1, time: 45000, errors: ['time'] })).first().content);
+    } catch (e) {
+      state.finished = true;
+      state.timeout = true;
+      return;
+    }
+
+    // full command name, directly after prefix
+    switch (response[1]) {
+      case ('confirm') : {
+        // stop here and begin trade confirmation
+        state.finished = true;
+        state.continue = true;
+        return;
+      }
+
+      case ('cancel'): {
+        // stop here but don't continue
+        state.finished = true;
+        return;
+      }
+
+      // not confirm or cancel so must be add/remove
+      default: {
+
+        // the second half of the command name, as in -offer<<item>>, etc
+        switch (response[3]) {
+          case ('item'): {
+            // check this item exists and get its data
+            const { name, amount } = this.detectAmount(response[4]);
+
+            if (amount < 0)
+              return message.channel.send(`Can't ${response[2]} less than none of an item.`);
+            if (amount >= 100)
+              return message.channel.send(`I think ${response[2]}ing THAT many is a bit too much.`);
+
+            const relevantItem = await this.client.db.getStoreItemByName(connection, name);
+            if (!relevantItem)
+              return message.channel.send('Not sure what this item is.');
+
+            const thisMap = (response[2] === 'offer' ? state.offerItems : state.requestItems);
+
+            if (!thisMap.has(relevantItem.id) && thisMap.size >= 8)
+              return message.channel.send(`Too many items ${response[2]}ed already. You can remove one by typing \`${message.settings.prefix}${response[2]}item <item> 0\`.`);
+
+            if (amount > 0)
+              thisMap.set(relevantItem.id, { amount: amount, definition: relevantItem });
+            else
+              thisMap.delete(relevantItem.id);
+            
+            return;
+          }
+
+          case ('blob'): {
+            // check this blob exists and get its data
+            const { name, amount } = this.detectAmount(response[4]);
+
+            if (amount < 0)
+              return message.channel.send(`Can't ${response[2]} less than none of a blob.`);
+            if (amount >= 100)
+              return message.channel.send(`I think ${response[2]}ing THAT many is a bit too much.`);
+
+            const relevantBlob = await this.client.db.getBlobByName(connection, name);
+            if (!relevantBlob)
+              return message.channel.send('Not sure what this blob is.');
+
+            const thisMap = (response[2] === 'offer' ? state.offerBlobs : state.requestBlobs);
+
+            if (!thisMap.has(relevantBlob.unique_id) && thisMap.size >= 8)
+              return message.channel.send(`Too many blobs ${response[2]}ed already. You can remove one by typing \`${message.settings.prefix}${response[2]}blob <blob> 0\`.`);
+
+            if (amount > 0)
+              thisMap.set(relevantBlob.unique_id, { amount: amount, definition: relevantBlob });
+            else
+              thisMap.delete(relevantBlob.unique_id);
+            
+            return;
+          }
+
+          case ('coin'): {
+            // check this amount is valid
+            const relevantCoins = parseInt(response[4]);
+            if (isNaN(relevantCoins) || relevantCoins < 0)
+              return message.channel.send('Please use a valid amount of coins.');
+
+            if (relevantCoins >= 100000)
+              return message.channel.send('I would avoid crashing the economy right now.');
+
+            switch (response[2]) {
+              case ('offer'): {
+                state.offerCoins = relevantCoins;
+                return;
+              }
+              default: {
+                state.requestCoins = relevantCoins;
+                return;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  detectAmount(text) {
+    const args = text.split(' ');
+    const maybeAmount = parseInt(args[args.length - 1]);
+    if (isNaN(maybeAmount)) {
+      return {amount: 1, name: text};
+    } else {
+      return {amount: maybeAmount, name: args.slice(0, -1).join(' ')};
+    }
+  }
+
+  async attemptPerformTrade(connection, message, state, correspondent) {
+    await connection.query('BEGIN');
+    let ok = false;
+    try {
+      // coins
+      if (state.offerCoins) {
+        if (!(await this.client.db.takeUserCurrency(connection, message.guild.id, message.author.id, state.offerCoins)))
+          return `${message.author} does not have ${state.offerCoins} coin(s).`;
+        await this.client.db.giveUserCurrency(connection, message.guild.id, correspondent.user.id, state.offerCoins);
+      }
+
+      if (state.requestCoins) {
+        if (!(await this.client.db.takeUserCurrency(connection, message.guild.id, correspondent.user.id, state.requestCoins)))
+          return `${correspondent.user} does not have ${state.requestCoins} coin(s).`;
+        await this.client.db.giveUserCurrency(connection, message.guild.id, message.author.id, state.requestCoins);
+      }
+
+      // items
+      if (state.offerItems.size > 0)
+        for (const itemSet of state.offerItems.values()) {
+          if (!(await this.client.db.removeUserItem(connection, message.guild.id, message.author.id, itemSet.definition.id, itemSet.amount)))
+            return `${message.author} does not have ${itemSet.amount}x ${itemSet.definition.name}`;
+          await this.client.db.giveUserItem(connection, message.guild.id, correspondent.user.id, itemSet.definition.id, itemSet.amount);
+        }
+
+      if (state.requestItems.size > 0)
+        for (const itemSet of state.requestItems.values()) {
+          if (!(await this.client.db.removeUserItem(connection, message.guild.id, correspondent.user.id, itemSet.definition.id, itemSet.amount)))
+            return `${correspondent.user.id} does not have ${itemSet.amount}x ${itemSet.definition.name}`;
+          await this.client.db.giveUserItem(connection, message.guild.id, message.author.id, itemSet.definition.id, itemSet.amount);
+        }
+
+      // blobs
+      if (state.offerBlobs.size > 0)
+        for (const blobSet of state.offerBlobs.values()) {
+          if (!(await this.client.db.takeUserBlob(connection, message.guild.id, message.author.id, blobSet.definition.unique_id, blobSet.amount)))
+            return `${message.author} does not have ${blobSet.amount}x <:${blobSet.definition.emoji_name}:${blobSet.definition.emoji_id}>`;
+          await this.client.db.giveUserBlob(connection, message.guild.id, correspondent.user.id, blobSet.definition.unique_id, blobSet.amount);
+        }
+
+      if (state.requestBlobs.size > 0)
+        for (const blobSet of state.requestBlobs.values()) {
+          if (!(await this.client.db.takeUserBlob(connection, message.guild.id, correspondent.user.id, blobSet.definition.unique_id, blobSet.amount)))
+            return `${correspondent.user.id} does not have ${blobSet.amount}x <:${blobSet.definition.emoji_name}:${blobSet.definition.emoji_id}>`;
+          await this.client.db.giveUserBlob(connection, message.guild.id, message.author.id, blobSet.definition.unique_id, blobSet.amount);
+        }
+
+      ok = true;
+    } finally {
+      if (!ok)
+        await connection.query('ROLLBACK');
+      else
+        await connection.query('COMMIT');
     }
   }
 }

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -29,6 +29,9 @@ class Trade extends Command {
     if (!correspondent)
       return message.channel.send('I don\'t understand who you\'re trying to trade with. Try using their mention.');
 
+    if (correspondent.user.id === message.author.id)
+      return message.channel.send(`${message.author}, don't you think it's time you got some real friends to trade with?`);
+
     if ((new Date() - message.member.joinedAt) < 604800000)
       return message.channel.send('You haven\'t been in the server long enough to initiate trades yet.');
 


### PR DESCRIPTION
This rewrites the entire trade command into an interactive one that allows for more diverse trading.

Pros:
* Users can do uneven trades, e.g. 3 blobs for 1
* Users can include any of items, blobs or coins in their trade, allowing people to do more dynamic trades, e.g. 1 rare blob for 1 common blob + 2 items
* Format allows users receiving trades to more clearly see what they'll be getting and losing out of the trade.

Cons:
* Can get **very** spammy, this is mitigated slightly by old embeds being deleted as the command progresses.
* As tracking the inventory, blobs and user profile state while the command executes would be either inconsistent or a pain, users can offer blobs or such they don't have, and the trade will only fail once both parties have agreed they like the trade.
* Low-level or new users are no longer able to trade as they get blocked in order to mitigate account duping - the alternative to this is risking users being able to accumulate currency or items through other accounts.
* More complex trades will be harder to log and keep track of

Probably largest single-commit PR I'll be doing. Tested and everything seems to work in terms of consistency.