### PR TITLE
Fixes for uptime & stability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       # run tests!
       - run:
           name: faux start bot
-          command: npm start
+          command: bash .docker/startloop.sh
           no_output_timeout: 20s
           environment:
             POKEBLOB_TEST_ONLY: true
@@ -113,7 +113,7 @@ jobs:
       # run tests!
       - run:
           name: faux start bot
-          command: npm start
+          command: bash .docker/startloop.sh
           no_output_timeout: 20s
           environment:
             POKEBLOB_TEST_ONLY: true

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:9
 
 RUN mkdir -p /nodedeps/node_modules
 
@@ -11,4 +11,4 @@ WORKDIR /app
 
 ENV NODE_PATH=/nodedeps/node_modules
 
-CMD ["npm", "start"]
+CMD ["bash", ".docker/startloop.sh"]

--- a/.docker/startloop.sh
+++ b/.docker/startloop.sh
@@ -1,0 +1,21 @@
+
+for waitstep in {5..1}
+do
+    echo "waiting for the db to catch up ($waitstep seconds)..";
+    sleep 1;
+done
+
+export firstNpmStartTime=$(date +%s);
+while [ 1 ];
+do
+    export lastNpmStartTime=$(date +%s);
+    npm start;
+    export npmExitCode=$?;
+    test $npmExitCode -eq 0 && break;
+    test $(expr $(date +%s) - 20) -lt $firstNpmStartTime && echo "died unreasonably quickly, propagating." && exit $npmExitCode;
+    test $(expr $(date +%s) - 90) -lt $lastNpmStartTime && echo "died too quickly, extending wait by 60 seconds.." && sleep 60;
+    echo "died for unknown reason; waiting 10 seconds before restarting..";
+    sleep 10;
+done
+
+echo "died by either interrupt or standard exit; not restarting";


### PR DESCRIPTION
This PR does a number of things:
* Bumps us up to Node9 over Node8
* Uses a bash script to deal with disconnects
  - If the bot dies within 20 seconds of it first starting, the error is propagated (under the assumption the build failed)
  - If the bot dies within 90 seconds of the last time it started it waits an additional 60 seconds (+the normal 10 = 70 second restart delay)
  - If the bot dies with a non-zero (it disconnected and timed out or crashed for any other reason) it'll wait 10 seconds before restarting
  - If the bot dies with a zero exit code, it exits normally (covers keyboard interrupts, exit by script, etc)

Since this changes CMD and the node version, it requires a container rebuild:
```sh
docker-compose down
docker-compose rm -f
docker-compose build --no-cache
docker-compose up
```