### PR TITLE
Clarify README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,9 @@ First, we need to install all dependencies.
 
 .. code-block:: sh
 
-   npm install
+   node util/setup.js
 
-While docker-compose installs all of the dependencies itself, you do need to install them yourself to run the setup script, which writes the config for you. After the first install of deps, if you ever rebuild the container, docker-compose can handle that, once the config is written, it stays. 
+Running util/setup.js will run the setup script. During this, it'll prompt you for your token. Simply input it, and it'll write the config for you.
 
 .. code-block:: sh
 

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,9 @@ First, we need to install all dependencies.
 
 .. code-block:: sh
 
-   node util/setup.js
+   node ./util/setup.js
 
-Running util/setup.js will run the setup script. During this, it'll prompt you for your token. Simply input it, and it'll write the config for you.
+Running this setup.js file will prompt you for your token. Simply input it, and it'll write the config for you.
 
 .. code-block:: sh
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ First, we need to install all dependencies.
 
    npm install
 
-After all the dependencies install, you will be prompted for your bots token. Simply paste that into the console, and hit enter. The setup script will write the config for you. After the config is written, you need to then launch the bot with docker-compose.
+While docker-compose installs all of the dependencies itself, you do need to install them yourself to run the setup script, which writes the config for you. After the first install of deps, if you ever rebuild the container, docker-compose can handle that, once the config is written, it stays. 
 
 .. code-block:: sh
 


### PR DESCRIPTION
This PR clarifies why you need to run `npm install` even when using docker-compose to launch the bot.