### PR TITLE
Don't track traded coins for milestones

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -281,13 +281,13 @@ class Trade extends Command {
       if (state.offerCoins) {
         if (!(await this.client.db.takeUserCurrency(connection, message.guild.id, message.author.id, state.offerCoins)))
           return `${message.author} does not have ${state.offerCoins} coin(s).`;
-        await this.client.db.giveUserCurrency(connection, message.guild.id, correspondent.user.id, state.offerCoins);
+        await this.client.db.giveUserUntrackedCurrency(connection, message.guild.id, correspondent.user.id, state.offerCoins);
       }
 
       if (state.requestCoins) {
         if (!(await this.client.db.takeUserCurrency(connection, message.guild.id, correspondent.user.id, state.requestCoins)))
           return `${correspondent.user} does not have ${state.requestCoins} coin(s).`;
-        await this.client.db.giveUserCurrency(connection, message.guild.id, message.author.id, state.requestCoins);
+        await this.client.db.giveUserUntrackedCurrency(connection, message.guild.id, message.author.id, state.requestCoins);
       }
 
       // items

--- a/util/db.js
+++ b/util/db.js
@@ -117,6 +117,17 @@ class DatabaseBackend {
     return res.rows[0];
   }
 
+  async giveUserUntrackedCurrency(client, guildID, memberID, amount) {
+    const member = await this.ensureMember(client, guildID, memberID);
+    const res = await client.query(`
+      UPDATE users
+      SET currency = users.currency + $1
+      WHERE unique_id = $2::BIGINT
+      RETURNING id, guild, currency, accumulated_currency
+    `, [amount, member.unique_id]);
+    return res.rows[0];
+  }
+
   async takeUserCurrency(client, guildID, memberID, amount) {
     const member = await this.ensureMember(client, guildID, memberID);
     const res = await client.query(`


### PR DESCRIPTION
As said on tin, this adds a method to db.js that allows coins to be incremented without increasing their lifetime total, and uses it in trades to avoid farming by coin trades.