### PR TITLE
Fix some user interactions in -search

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -40,7 +40,7 @@ class Search extends Command {
 
     let response;
     try {
-      response = re.exec((await message.channel.awaitMessages(filter, { max: 1, time: 60000, errors: ['time'] })).first().content);
+      response = re.exec((await message.channel.awaitMessages(filter, { max: 1, time: 120000, errors: ['time'] })).first().content);
     } catch (e) {
       return { threwBall: false, usedBall: null };
     }
@@ -117,6 +117,9 @@ class Search extends Command {
 
         if (!threwBall) return;
 
+        // the user didn't cancel or search-by; re-engage lock
+        this.activeSearches.set(message.author.id);
+
         await connection.query('BEGIN');
         const consumed = await this.client.db.removeUserItem(connection, message.guild.id, message.author.id, usedBall.item_id, 1);
 
@@ -152,6 +155,9 @@ class Search extends Command {
           msg = await message.channel.send(`${message.author} You try to use your ${usedBall.name}, but the <:${blob.emoji_name}:${blob.emoji_id}> breaks free. ${desc2}`);
 
           if (!aC2) return;
+
+          // release lock again for second catch
+          this.activeSearches.delete(message.author.id);
 
           const { threwBall: tB2, usedBall: uB2 } = await this.waitForCatchResponse(message, userPokeBalls, escapedPrefix);
 


### PR DESCRIPTION
This bumps the time waited for catching blobs to 120 seconds over 60 and attempts to fix the [catch interactive state bug](https://cdn.discordapp.com/attachments/398318976402456586/405756421838340107/Screenshot_from_2018-01-24_16-04-42.png).
No good way of confirming 100% if this will end up fixing the bug for good since it's hard to test properly out of prod, but hopes is that this should at least mitigate some of those cases.